### PR TITLE
Version 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # lehtiolab/ddamsproteomics: Changelog
+## Version 2.15 [2023-08-25]
+- Revert to --ignore-target-hits for decoy generation, do not remove decoy tryptic peptides that match target
+
+
 ## Version 2.14 [2023-08-22]
 - Fixed off-by-one error in PTM site nr reporting on proteins (#17)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ RUN apt update && apt install -y fontconfig && apt clean -y
 
 COPY environment.yml /
 RUN conda env create -f /environment.yml && conda clean -a
-ENV PATH /opt/conda/envs/ddamsproteomics-2.14/bin:$PATH
+ENV PATH /opt/conda/envs/ddamsproteomics-2.15/bin:$PATH

--- a/Singularity
+++ b/Singularity
@@ -3,10 +3,10 @@ Bootstrap:docker
 
 %labels
     DESCRIPTION Singularity image containing all requirements for the lehtiolab/ddamsproteomics pipeline
-    VERSION 2.14
+    VERSION 2.15
 
 %environment
-    PATH=/opt/conda/envs/ddamsproteomics-2.14/bin:$PATH
+    PATH=/opt/conda/envs/ddamsproteomics-2.15/bin:$PATH
     export PATH
 
 %files

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,7 +120,10 @@ Examples of instruments can be found in [this MSGF+ parameter file](https://gith
 
 ### Input sequences: `--tdb`
 Target database. Decoy databases are created "tryptic-reverse" by the pipeline and searches are against a
-concatenated database (T-TDC). Default behaviour for MSGF+ is to not limit missed cleavage amount, but that can
+concatenated database (T-TDC). Decoy database proteins are thus the same length as target while keeping
+tryptic residues in place. Tryptic peptides are shuffled but not removed if they match a tryptic peptide
+in the target database.
+Default behaviour for MSGF+ is to not limit missed cleavage amount, but that can
 if desired be set by `--maxmiscleav`. For limiting peptide length you may use `--minpeplen` and `--maxpeplen`, while
 allowed charge states can be controlled with `--mincharge`, `--maxcharge`.
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: ddamsproteomics-2.14
+name: ddamsproteomics-2.15
 channels:
   - bioconda
   - conda-forge

--- a/main.nf
+++ b/main.nf
@@ -486,7 +486,7 @@ process createTargetDecoyFasta {
   """
   ${tdb.size() > 1 ? "cat ${tdb.collect() { "\"${it}\"" }.join(' ')} > tdb" : "mv '$tdb' tdb"}
   check_fasta.py tdb
-  msstitch makedecoy -i tdb -o decoy.fa --scramble tryp_rev
+  msstitch makedecoy -i tdb -o decoy.fa --scramble tryp_rev --ignore-target-hits
   cat tdb decoy.fa > db.fa
   """
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -20,7 +20,7 @@ params {
 }
 
 // Container slug. Stable releases should specify release tag!
-process.container = 'lehtiolab/ddamsproteomics:2.14'
+process.container = 'lehtiolab/ddamsproteomics:2.15'
 //process.container = 'ddamsproteomics:dev'
 
 profiles {
@@ -90,7 +90,7 @@ manifest {
   description = 'Quantitative DDA MS proteomics pipeline'
   mainScript = 'main.nf'
   nextflowVersion = '>=20.01.0'
-  version = '2.14'
+  version = '2.15'
 }
 
 // Function to ensure that resource requirements don't go beyond


### PR DESCRIPTION
Fixes removal of decoy peptides that match target database, which skews decoy database towards longer peptides, fewer missed-cleavage hits and bad PSMs in the target fraction.

Fixes #19 